### PR TITLE
Rewite of millis use to prevent problems with overflow

### DIFF
--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -781,7 +781,7 @@ void UpdateDisplay() {
   // deal with the case that no data has arrived beyond the timeout period
   // see the notes in the general_settings.h file for more information
 
-  if (millis() > (lastMQTTUpdateReceived + timeOutInMilliSeconds)) {
+  if (millis() - lastMQTTUpdateReceived > timeOutInMilliSeconds) {
 
     sprite.fillSprite(TFT_BLACK);
     sprite.loadFont(NotoSansBold24);

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -750,7 +750,7 @@ void UpdateDisplay() {
     SetTheDisplayOn(true);
 
   // only update the display when its time has come
-  if (millis() - lastDisplayUpdate >= ((unsigned long)GENERAL_SETTINGS_SECONDS_BETWEEN_DISPLAY_UPDATES * 1000UL))
+  if (millis() - lastDisplayUpdate < ((unsigned long)GENERAL_SETTINGS_SECONDS_BETWEEN_DISPLAY_UPDATES * 1000UL))
     return;
 
   // only update the display if it is on

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -1,10 +1,11 @@
-// ESP32 Victron Monitor (version 1.9.3)
+// ESP32 Victron Monitor (version 1.9.4)
 //
 // Copyright Rob Latour, 2024
 // License: MIT
 // https://github.com/roblatour/ESP32RemoteForVictron
 //
 
+// version 1.9.4 - Made the use of millis roll over safe
 // version 1.9.3 - removed reference to timezone.h; refactoring of variable names; updated comments for SECRET_SETTINGS_MQTT_Broker
 // version 1.9.2 - after further review removed unneeded millis() roll over logic;
 //                 thanks to Nonstle for pointing this out at: https://github.com/roblatour/ESP32RemoteForVictron/issues/4
@@ -60,7 +61,7 @@
 
 // Globals
 const String programName = "ESP32 Remote for Victron";
-const String programVersion = "(Version 1.9.3)";
+const String programVersion = "(Version 1.9.4)";
 const String programURL = "https://github.com/roblatour/ESP32RemoteForVictron";
 
 RTC_DATA_ATTR bool initialStartupShowSplashScreen = true;

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -146,7 +146,6 @@ FireTimer msTimer;
 // Time stuff
 #include <ESP32Time.h>
 #include <TimeLib.h>   // version 1.6.1  https://www.arduino.cc/reference/en/libraries/time/
-#include <Timezone.h>  // Include the Timezone library
 #include <WiFi.h>
 #include <time.h>
 

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -629,7 +629,7 @@ void RefreshTimeOnceADay(bool forceTimeSet = false) {
   static unsigned long lastTimeCheck = 0UL;
   static unsigned long checkInterval = 0UL; 
 
-  if (forceTimeSet || (millis() - lastTimeCheck > checkInterval)) {
+  if (forceTimeSet || (millis() - lastTimeCheck >= checkInterval)) {
     lastTimeCheck = millis();
     if (SetTime()) {
       checkInterval = ONE_DAY_IN_MILLIS;
@@ -780,7 +780,7 @@ void UpdateDisplay() {
   // deal with the case that no data has arrived beyond the timeout period
   // see the notes in the general_settings.h file for more information
 
-  if (millis() - lastMQTTUpdateReceived > timeOutInMilliSeconds) {
+  if (millis() - lastMQTTUpdateReceived >= timeOutInMilliSeconds) {
 
     sprite.fillSprite(TFT_BLACK);
     sprite.loadFont(NotoSansBold24);
@@ -1155,7 +1155,7 @@ void KeepMQTTAlive(bool forceKeepAliveRequestNow = false) {
 
   if ((forceKeepAliveRequestNow) || (GENERAL_SETTINGS_SEND_PERIODICAL_KEEP_ALIVE_REQUESTS)) {
 
-    if ((forceKeepAliveRequestNow) || (millis() - lastMqttUpdate > GENERAL_SETTINGS_SEND_PERIODICAL_KEEP_ALIVE_REQUESTS_INTERVAL)) {
+    if ((forceKeepAliveRequestNow) || (millis() - lastMqttUpdate >= GENERAL_SETTINGS_SEND_PERIODICAL_KEEP_ALIVE_REQUESTS_INTERVAL)) {
 
       lastMqttUpdate = millis();   
 

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -1152,15 +1152,13 @@ void ResetGlobals() {
 
 void KeepMQTTAlive(bool forceKeepAliveRequestNow = false) {
 
-  static unsigned long nextUpdate = 0UL;
+  static unsigned long lastMqttUpdate = 0UL;
 
   if ((forceKeepAliveRequestNow) || (GENERAL_SETTINGS_SEND_PERIODICAL_KEEP_ALIVE_REQUESTS)) {
 
-    if ((forceKeepAliveRequestNow) || (millis() > nextUpdate)) {
+    if ((forceKeepAliveRequestNow) || (millis() - lastMqttUpdate > GENERAL_SETTINGS_SEND_PERIODICAL_KEEP_ALIVE_REQUESTS_INTERVAL)) {
 
-      const unsigned long secondsBetweenKeepAliveRequests = 30UL;
-
-      nextUpdate = millis() + secondsBetweenKeepAliveRequests * 1000UL;   
+      lastMqttUpdate = millis();   
 
       client.publish("R/" + VictronInstallationID + "/keepalive", "");
 

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -730,7 +730,7 @@ bool ShouldTheDisplayBeOn() {
 
 void UpdateDisplay() {
 
-  static unsigned long nextDisplayUpdate = 0UL;
+  static unsigned long lastDisplayUpdate = 0UL;
   static bool tryToRestoreConnection = true;
   static bool MQTTTransmissionLost = false;
 
@@ -744,7 +744,7 @@ void UpdateDisplay() {
     SetTheDisplayOn(true);
 
   // only update the display when its time has come
-  if (millis() < nextDisplayUpdate)
+  if (millis() - lastDisplayUpdate >= ((unsigned long)GENERAL_SETTINGS_SECONDS_BETWEEN_DISPLAY_UPDATES * 1000UL))
     return;
 
   // only update the display if it is on
@@ -859,7 +859,7 @@ void UpdateDisplay() {
     };
   };
 
-  nextDisplayUpdate = millis() + ((unsigned long)GENERAL_SETTINGS_SECONDS_BETWEEN_DISPLAY_UPDATES * 1000UL);
+  lastDisplayUpdate = millis();
 
   int x, y;
 

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -113,10 +113,10 @@ int topButton, bottomButton;
 // Display
 #include <TFT_eSPI.h>              // download and use the entire TFT_eSPI https://github.com/Xinyuan-LilyGO/LilyGo-AMOLED-Series/tree/master/libdeps
 #include "rm67162.h"               // included in the github package for this sketch, but also available from https://github.com/Xinyuan-LilyGO/T-Display-S3-AMOLED/tree/main/examples/factory
-#include "fonts\NotoSansBold15.h"  // included in the github package for this sketch, based on https://fonts.google.com/noto/specimen/Noto+Sans
-#include "fonts\NotoSansBold24.h"  // "
-#include "fonts\NotoSansBold36.h"  // "
-#include "fonts\NotoSansBold72.h"  // "
+#include "fonts/NotoSansBold15.h"  // included in the github package for this sketch, based on https://fonts.google.com/noto/specimen/Noto+Sans
+#include "fonts/NotoSansBold24.h"  // "
+#include "fonts/NotoSansBold36.h"  // "
+#include "fonts/NotoSansBold72.h"  // "
 
 TFT_eSPI tft = TFT_eSPI();
 TFT_eSprite sprite = TFT_eSprite(&tft);

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -155,7 +155,6 @@ const char *tertiaryNTPSever = GENERAL_SETTINGS_TERTIARY_TIME_SERVER;
 const char *timeZone = GENERAL_SETTINGS_MY_TIME_ZONE;
 
 bool turnOnDisplayAtSpecificTimesOnly = GENERAL_SETTINGS_TURN_ON_DISPAY_AT_SPECIFIC_TIMES_ONLY;
-unsigned long nextTimeCheck = 0UL;
 unsigned long keepTheDisplayOnUntilAtLeastThisTime = 0UL;
 
 // report a timeout after this many seconds of no data being received
@@ -627,18 +626,18 @@ void RefreshTimeOnceADay(bool forceTimeSet = false) {
   const int RETRY_INTERVAL_IN_MINUTES = 20;
   const unsigned long RETRY_INTERVAL_IN_MILLIS = RETRY_INTERVAL_IN_MINUTES * 60UL * 1000UL;
   const unsigned long ONE_DAY_IN_MILLIS = 24UL * 60UL * 60UL * 1000UL;
+  static unsigned long lastTimeCheck = 0UL;
+  static unsigned long checkInterval = 0UL; 
 
-  if (forceTimeSet || (millis() > nextTimeCheck)) {
-
+  if (forceTimeSet || (millis() - lastTimeCheck > checkInterval)) {
+    lastTimeCheck = millis();
     if (SetTime()) {
-      nextTimeCheck = millis() + ONE_DAY_IN_MILLIS;
-
+      checkInterval = ONE_DAY_IN_MILLIS;
     } else {
-      nextTimeCheck = millis() + RETRY_INTERVAL_IN_MILLIS;
+      checkInterval = RETRY_INTERVAL_IN_MILLIS;
       // keep the display on until the time can be successfully set from the NTP server
       KeepTheDisplayOnForThisManyMinutes(RETRY_INTERVAL_IN_MINUTES + 1);
     };
-  
   };
 };
 

--- a/ESP32RemoteForVictron/general_settings.h
+++ b/ESP32RemoteForVictron/general_settings.h
@@ -104,6 +104,7 @@
                                                                                //
                                                                                // 5. regardless of if this option is set to true or false, if you see the message "Awaiting MQTT connection" appear 
                                                                                //    on your screen and stay there it likely means Venus itself is no longer transmitting MQTT data 
+#define GENERAL_SETTINGS_SEND_PERIODICAL_KEEP_ALIVE_REQUESTS_INTERVAL 30000    // Time between keep alive requests in ms
 
 #define GENERAL_SETTINGS_ENABLE_OVER_THE_AIR_UPDATES                   true    // set to true to enable OTA updates, set to false to disable OTA updates
 


### PR DESCRIPTION
Millis will overflow every 49 days roughly. I rewrote the use of it to be relative instead of exact. Taking advantage of the possible underflow of a minus calculation to still give us the correct answer as long as the interval that is being measured is less then 49 days.

Fixed small bug since last pull request.

## Summary by Sourcery

Rewrite the use of millis() to handle overflow by using relative time calculations, ensuring correct functionality for intervals less than 49 days. Refactor display timeout logic and fix a small bug from the previous pull request.

Bug Fixes:
- Fix a small bug from the previous pull request.

Enhancements:
- Refactor the display timeout logic to use relative time calculations, preventing issues with millis() overflow.