### PR TITLE
Added a General info option to show batt power

### DIFF
--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -1176,7 +1176,17 @@ void UpdateDisplay()
     sprite.loadFont(NotoSansBold15);
     int degreePosx = sprite.textWidth(temperatureString) / 2 + 4;
     sprite.drawString(String("o"), midX + degreePosx, midY + 43);
-  };
+  }  
+  else if (GENERAL_SETTINGS_ADDITIONAL_INFO == 4) 
+  {
+
+    //show battery power
+    if (GENERAL_SETTINGS_IF_OVER_1000_WATTS_REPORT_KW && ((batteryPower >= 1000.0F) || (batteryPower <= -1000.0F))) {
+      sprite.drawString(ConvertToStringWithAFixedNumberOfDecimalPlaces(batteryPower / 1000.0F, GENERAL_SETTINGS_NUMBER_DECIMAL_PLACES_FOR_KW_REPORTING) + " kW", midX, midY + 50);
+    } else {
+      sprite.drawString(String(int(batteryPower)) + " W", midX, midY + 50);
+    };
+  }
 
   sprite.unloadFont();
 
@@ -1618,6 +1628,13 @@ void MassSubscribe()
 
     msTimer.begin(100);
     break;
+
+    case 4:
+
+      awaitingDataToBeReceived[6] = false;
+      awaitingDataToBeReceived[7] = false;
+      awaitingDataToBeReceived[8] = false;
+      break;
 
   default:
     break;

--- a/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
+++ b/ESP32RemoteForVictron/ESP32RemoteForVictron.ino
@@ -1,9 +1,10 @@
-// ESP32 Victron Monitor (version 1.9.6)
+// ESP32 Victron Monitor (version 1.9.7)
 //
 // Copyright Rob Latour, 2025
 // License: MIT
 // https://github.com/roblatour/ESP32RemoteForVictron
 //
+// version 1.9.7 - added option to show wattage coming into / going out of battery
 // version 1.9.6 - corrected problem with displaying total AC Load; ShouldTheDisplayBeOn tweaked to ensure SleepTime is correctly calculated
 // version 1.9.5 - adjusted calculation of solar watts and total grid watts when over 100kw to avoid displaying wrong results if updates not received when expected
 // version 1.9.4 - Made the use of millis roll over safe
@@ -62,7 +63,7 @@
 
 // Globals
 const String programName = "ESP32 Remote for Victron";
-const String programVersion = "(Version 1.9.6)";
+const String programVersion = "(Version 1.9.7)";
 const String programURL = "https://github.com/roblatour/ESP32RemoteForVictron";
 
 RTC_DATA_ATTR bool initialStartupShowSplashScreen = true;

--- a/ESP32RemoteForVictron/general_settings.h
+++ b/ESP32RemoteForVictron/general_settings.h
@@ -25,6 +25,7 @@
                                                                                // 1 = show Time To Go (remaining battery time); note this value is only available when the battery is discharging
                                                                                // 2 = show Solar Charger (mppt) / Multiplus charging state: Off/Fault/Bulk/Absorption/Float/Storage/Equalize/ESS
                                                                                // 3 = show battery temperature
+                                                                               // 4 = show battery power, positive number means power going into the battery, negative number means power going out of the battery
 
                                                                                // if any of the following are not used in your installation then you can set the associated value(s) below to false to reduce unneeded MQTT traffic:
 #define GENERAL_SETTINGS_GRID_IN_L1_IS_USED                            true    // set to true if Grid IN L1 is used in your installation, otherwise set to false


### PR DESCRIPTION
Hey Rob,

How are you doing? Hope you've been well. I tried emailing you but it came back as undeliverable.

In my use case I'm sometimes curious to see what the actual power level is going in or out of the battery. So I added it:). Great thing about open source.

I've added an option to GENERAL_SETTINGS_ADDITIONAL_INFO. You already gathered the battery power level in batteryPower so I didn't need to do anything to get this information from the Victron, just had to display it. I'm not quite sure what's happening in the switch statement but I've added a forth case on line 1632 basically doing the same as case 0 where also no new information is needed. Maybe that's not a 100% correct.

It looks like this when charging:
![image](https://github.com/user-attachments/assets/8d5df702-f3cb-4271-80ae-8a04ec1747a9)

And like this when discharging:
![image](https://github.com/user-attachments/assets/8b8a4145-12b7-45de-95bd-6fe777fe7602)

Anyway. Maybe you would like to add it to you repository as well. If you would like to add it feel free to copy the changes and commit them yourself to your repo. Or alternatively I can make adjustments if needed to this pull request again, whatever you want.

Kind regards,
René

## Summary by Sourcery

Add a new general information mode to display live battery power readings on screen.

New Features:
- Introduce option 4 in GENERAL_SETTINGS_ADDITIONAL_INFO to show battery power.
- Display battery power in watts or kilowatts based on configuration and magnitude.

Enhancements:
- Extend MassSubscribe to request battery power data for the new option.

Documentation:
- Update settings comment to document the new battery power option.